### PR TITLE
feat: 내정보 페이지  구현

### DIFF
--- a/components/molecules/ContactItem/index.tsx
+++ b/components/molecules/ContactItem/index.tsx
@@ -4,14 +4,16 @@ import React from "react";
 import styled from "styled-components";
 
 interface Props {
+  title?: string;
   name: string;
-  text: string;
+  text: string | number;
 }
 
-const ContactItem = ({ name, text }: Props) => {
+const ContactItem = ({ title, name, text }: Props) => {
   return (
     <StyledContactItem>
       <Image name={name} />
+      <Text>{title} : </Text>
       <Text>{text}</Text>
     </StyledContactItem>
   );
@@ -22,7 +24,12 @@ const StyledContactItem = styled.div`
   margin: 4px 0;
 
   p {
-    margin: 0 10px;
+    :nth-child(2) {
+      margin: 0 4px;
+    }
+    :nth-child(3) {
+      margin-left: 2px;
+    }
   }
 `;
 

--- a/components/molecules/GuestItem/index.tsx
+++ b/components/molecules/GuestItem/index.tsx
@@ -53,6 +53,10 @@ const GuestHeader = styled.div`
   height: 18px;
   padding: 0 20px;
   background-color: ${({ theme }) => theme.color.normalGray};
+
+  button {
+    color: ${({ theme }) => theme.color.darkGray};
+  }
 `;
 
 const HeaderTitle = styled.div`
@@ -71,8 +75,8 @@ const HeaderTitle = styled.div`
 
 const GuestContent = styled.div`
   display: flex;
-  height: 60px;
-  padding: 13px 0 13px 20px;
+  height: 70px;
+  padding: 10px 0 0 20px;
 
   > p {
     margin-left: 20px;
@@ -88,6 +92,7 @@ const GuestContent = styled.div`
   }
   img {
     width: 70px;
+    padding-bottom: 10px;
   }
 `;
 

--- a/components/molecules/infoItem/index.tsx
+++ b/components/molecules/infoItem/index.tsx
@@ -27,7 +27,7 @@ const InfoItem = ({
       <Title>{name}: </Title>
       <Input
         name={name}
-        value={value}
+        value={value ?? ""}
         type={type}
         placeholder={placeholder}
         onChange={onChange}

--- a/components/molecules/infoItem/index.tsx
+++ b/components/molecules/infoItem/index.tsx
@@ -41,7 +41,7 @@ const StyledInfo = styled.div`
   width: 100%;
   display: flex;
   align-items: center;
-  margin-bottom: 10px;
+  margin: 5px 0;
 
   > p {
     margin-right: 10px;

--- a/components/molecules/infoItem/index.tsx
+++ b/components/molecules/infoItem/index.tsx
@@ -1,0 +1,57 @@
+import Input from "components/atoms/Input";
+import Title from "components/atoms/Title";
+import React from "react";
+import styled from "styled-components";
+
+interface Props {
+  name: string;
+  value: string | number;
+  type?: string;
+  placeholder?: string;
+  readOnly?: boolean;
+  onChange: (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+}
+
+const InfoItem = ({
+  name,
+  value,
+  type,
+  placeholder,
+  readOnly,
+  onChange,
+}: Props) => {
+  return (
+    <StyledInfo>
+      <Title>{name}: </Title>
+      <Input
+        name={name}
+        value={value}
+        type={type}
+        placeholder={placeholder}
+        onChange={onChange}
+        readOnly={readOnly}
+      />
+    </StyledInfo>
+  );
+};
+
+const StyledInfo = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+
+  > p {
+    margin-right: 10px;
+  }
+
+  input::-webkit-inner-spin-button {
+    appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+  }
+`;
+
+export default InfoItem;

--- a/components/organisms/GuestWrapper/index.tsx
+++ b/components/organisms/GuestWrapper/index.tsx
@@ -44,6 +44,7 @@ const GuestWrapper = ({ query }: PageProps) => {
   );
 
   const handleDeleteGuest = async (id: string) => {
+    confirm("방명록을 삭제하시겠습니까?");
     const res = await deleteGuest({
       variables: { productId: id },
     });

--- a/components/organisms/InfoWrapper/index.tsx
+++ b/components/organisms/InfoWrapper/index.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import { useRouter } from "next/router";
+import Button from "components/atoms/Button";
+import Loading from "components/atoms/Loading";
+import InfoItem from "components/molecules/infoItem";
+import Contents from "../Contents";
+import { defaultWritter } from "constants/index";
+import {
+  GetProfileQueryResult,
+  GetProfileQueryVariables,
+  useGetProfileQuery,
+  useUpdateProfileMutation,
+} from "lib/graphql/queries/schema";
+
+const InfoWrapper = () => {
+  const router = useRouter();
+  const [name, setName] = useState<string>(defaultWritter);
+  const [school, setSchool] = useState<string>("");
+  const [age, setAge] = useState<string>("");
+
+  const { data: profileData, loading: profileDataLoading } = useGetProfileQuery(
+    {
+      variables: { name: defaultWritter } as GetProfileQueryVariables,
+    }
+  ) as GetProfileQueryResult;
+
+  const [updateProfile] = useUpdateProfileMutation();
+
+  const handleSubmit = async () => {
+    if (school === "" || age === "") {
+      alert("입력칸을 채워주세요");
+      return;
+    }
+    const res = await updateProfile({
+      variables: {
+        name,
+        school,
+        age: Number(age),
+      },
+    });
+    if (!res) {
+      alert("프로필 수정 실패");
+      return;
+    }
+    const alertMessage = res?.data?.updateProfile?.message;
+    alert(alertMessage);
+    router.push("/info");
+  };
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { value, name } = event.target;
+
+    if (name === "학교") {
+      setSchool(value);
+    } else {
+      setAge(value);
+    }
+  };
+
+  useEffect(() => {
+    setName(profileData?.fetchProfile?.name!);
+    setSchool(profileData?.fetchProfile?.school!);
+    setAge(String(profileData?.fetchProfile?.age));
+  }, [profileData]);
+
+  return (
+    <Contents>
+      {profileDataLoading ? (
+        <Loading />
+      ) : (
+        <>
+          <InfoItem
+            name="이름"
+            value={name}
+            placeholder="이름을 입력해 주세요"
+            onChange={handleChange}
+            readOnly
+          />
+          <InfoItem
+            name="나이"
+            value={age}
+            type="number"
+            placeholder="나이를 입력해 주세요"
+            onChange={handleChange}
+          />
+          <InfoItem
+            name="학교"
+            value={school}
+            placeholder="학교를 입력해 주세요"
+            onChange={handleChange}
+          />
+          <ButtonBox>
+            <Button onClick={handleSubmit}>저장</Button>
+          </ButtonBox>
+        </>
+      )}
+    </Contents>
+  );
+};
+
+const ButtonBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 200px;
+`;
+
+export default InfoWrapper;

--- a/components/organisms/InfoWrapper/index.tsx
+++ b/components/organisms/InfoWrapper/index.tsx
@@ -1,17 +1,19 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useRouter } from "next/router";
-import Button from "components/atoms/Button";
-import Loading from "components/atoms/Loading";
-import InfoItem from "components/molecules/infoItem";
-import Contents from "../Contents";
-import { defaultWritter } from "constants/index";
 import {
   GetProfileQueryResult,
   GetProfileQueryVariables,
   useGetProfileQuery,
   useUpdateProfileMutation,
 } from "lib/graphql/queries/schema";
+import Title from "components/atoms/Title";
+import Divider from "components/atoms/Divider";
+import Button from "components/atoms/Button";
+import Loading from "components/atoms/Loading";
+import InfoItem from "components/molecules/infoItem";
+import Contents from "../Contents";
+import { defaultWritter } from "constants/index";
 
 const InfoWrapper = () => {
   const router = useRouter();
@@ -68,6 +70,8 @@ const InfoWrapper = () => {
 
   return (
     <Contents>
+      <Title>My Info</Title>
+      <Divider />
       {profileDataLoading ? (
         <Loading />
       ) : (

--- a/components/organisms/Profile/index.tsx
+++ b/components/organisms/Profile/index.tsx
@@ -1,21 +1,58 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
+import { useRouter } from "next/router";
+import {
+  GetProfileQueryResult,
+  GetProfileQueryVariables,
+  useGetProfileQuery,
+} from "lib/graphql/queries/schema";
 import Divider from "components/atoms/Divider";
 import Image from "components/atoms/Image";
 import Text from "components/atoms/Text";
 import ContactItem from "components/molecules/ContactItem";
 import SelectBox from "components/molecules/SelectBox";
-import { contactList, emotionList } from "constants/index";
+import { contactList, defaultWritter, emotionList } from "constants/index";
 
 const Profile = () => {
+  const router = useRouter();
+  const { data: profileData, refetch } = useGetProfileQuery({
+    variables: { name: defaultWritter } as GetProfileQueryVariables,
+  }) as GetProfileQueryResult;
+
+  useEffect(() => {
+    refetch();
+  }, [router]);
+
   return (
     <StyledProfile>
       <ProfileInfo>
         <Image name="profile" />
         <Divider />
-        {contactList?.map((item, index) => (
-          <ContactItem name={item.name} text={item.text} key={index} />
-        ))}
+        {!profileData ? (
+          <>
+            {contactList?.map((item, index) => (
+              <ContactItem name={item.name} text={item.text} key={index} />
+            ))}
+          </>
+        ) : (
+          <>
+            <ContactItem
+              title="이름"
+              name="face"
+              text={profileData?.fetchProfile?.name!}
+            />
+            <ContactItem
+              title="나이"
+              name="phone"
+              text={profileData?.fetchProfile?.age!}
+            />
+            <ContactItem
+              title="학교"
+              name="star"
+              text={profileData?.fetchProfile?.school!}
+            />
+          </>
+        )}
       </ProfileInfo>
       <ProfileEmotion>
         <Text>오늘의 기분</Text>
@@ -49,6 +86,7 @@ const ProfileInfo = styled.div`
 const ProfileEmotion = styled.div`
   display: flex;
   flex-direction: column;
+
   > p {
     margin-bottom: 5px;
     font-weight: bold;

--- a/components/templates/InfoContainer/index.tsx
+++ b/components/templates/InfoContainer/index.tsx
@@ -1,0 +1,15 @@
+import InfoWrapper from "components/organisms/InfoWrapper";
+import Profile from "components/organisms/Profile";
+import React from "react";
+import InnerBox from "../InnerBox";
+
+const InfoContainer = () => {
+  return (
+    <InnerBox>
+      <Profile />
+      <InfoWrapper />
+    </InnerBox>
+  );
+};
+
+export default InfoContainer;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -49,6 +49,7 @@ export const tabList: TabType[] = [
   { title: "게임", path: "/game", value: "/game" },
   { title: "다이어리", path: "/diary?page=1", value: "/diary" },
   { title: "방명록", path: "/guest?page=1", value: "/guest" },
+  { title: "내정보", path: "/info", value: "/info" },
 ];
 
 export const defaultWritter: string = "김헨리";

--- a/lib/graphql/mutation/updateProfile.graphql
+++ b/lib/graphql/mutation/updateProfile.graphql
@@ -1,0 +1,14 @@
+mutation updateProfile(
+  $name: String
+  $age: Int
+  $school: String 
+) {
+  updateProfile(
+    name: $name
+    age: $age
+    school: $school
+  ) {
+    message
+    number
+  }
+}

--- a/pages/info/index.tsx
+++ b/pages/info/index.tsx
@@ -1,0 +1,8 @@
+import InfoContainer from "components/templates/InfoContainer";
+import React from "react";
+
+const Info = () => {
+  return <InfoContainer />;
+};
+
+export default Info;


### PR DESCRIPTION
## 구현 내용
- 내정보 페이지에서 프로필 데이터 수정 구현
- 프로필 컴포넌트 데이터 통신해서 정보 나타냄 (프로필 정보는 '김헨리' 데이터 고정)


#### 내정보 페이지
<img width="596" alt="image" src="https://user-images.githubusercontent.com/70426440/197387010-5ddb0da2-64c8-40a4-a284-deccd32ee1ad.png">

#### 기존 프로필 컴포넌트 (정적)
<img width="218" alt="image" src="https://user-images.githubusercontent.com/70426440/197386903-b4bc9ed6-74d5-470d-9aaf-e7f519e608ef.png">

#### 수정한 프로필 컴포넌트 (동적)
<img width="217" alt="image" src="https://user-images.githubusercontent.com/70426440/197386912-b7ff9aad-cb63-43c7-b274-1aafbd05fd77.png">
